### PR TITLE
Fix: register Persist LibraryObject in Cpu.sw to fix broken publish

### DIFF
--- a/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
+++ b/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
@@ -9,6 +9,39 @@
   <TaskClass Name="Cyclic#7" />
   <TaskClass Name="Cyclic#8" />
   <Libraries>
+    <LibraryObject Name="ArEventLog" Source="Libraries._AS.ArEventLog.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsARCfg" Source="Libraries._AS.AsARCfg.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsArProf" Source="Libraries._AS.AsArProf.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrMath" Source="Libraries._AS.AsBrMath.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrStr" Source="Libraries._AS.AsBrStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsBrWStr" Source="Libraries._AS.AsBrWStr.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsEPL" Source="Libraries._AS.AsEPL.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsGuard" Source="Libraries._AS.AsGuard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsHttp" Source="Libraries._AS.AsHttp.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIO" Source="Libraries._AS.AsIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOAcc" Source="Libraries._AS.AsIOAcc.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIODiag" Source="Libraries._AS.AsIODiag.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsIOTime" Source="Libraries._AS.AsIOTime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsMem" Source="Libraries._AS.AsMem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsSem" Source="Libraries._AS.AsSem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsTCP" Source="Libraries._AS.AsTCP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUDP" Source="Libraries._AS.AsUDP.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsUSB" Source="Libraries._AS.AsUSB.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsXml" Source="Libraries._AS.AsXml.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="AsZip" Source="Libraries._AS.AsZip.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="astime" Source="Libraries._AS.astime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="brsystem" Source="Libraries._AS.brsystem.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="DataObj" Source="Libraries._AS.DataObj.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="dvframe" Source="Libraries._AS.dvframe.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="FileIO" Source="Libraries._AS.FileIO.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="LoopConR" Source="Libraries._AS.LoopConR.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTBasics" Source="Libraries._AS.MTBasics.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTLookUp" Source="Libraries._AS.MTLookUp.lby" Memory="UserROM" Language="Binary" Debugging="true" />
+    <LibraryObject Name="MTTypes" Source="Libraries._AS.MTTypes.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="operator" Source="Libraries._AS.operator.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="runtime" Source="Libraries._AS.runtime.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="standard" Source="Libraries._AS.standard.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="sys_lib" Source="Libraries._AS.sys_lib.lby" Memory="UserROM" Language="binary" Debugging="true" />
     <LibraryObject Name="Persist" Source="Libraries.Loupe.Persist.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
   </Libraries>
 </SwConfiguration>

--- a/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
+++ b/example/AsProject/Physical/ARM/X20CP0484/Cpu.sw
@@ -8,5 +8,7 @@
   <TaskClass Name="Cyclic#6" />
   <TaskClass Name="Cyclic#7" />
   <TaskClass Name="Cyclic#8" />
-  <Libraries />
+  <Libraries>
+    <LibraryObject Name="Persist" Source="Libraries.Loupe.Persist.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
+  </Libraries>
 </SwConfiguration>

--- a/example/AsProject/Physical/Intel/5APC4100_TGL1_000/Cpu.sw
+++ b/example/AsProject/Physical/Intel/5APC4100_TGL1_000/Cpu.sw
@@ -56,5 +56,6 @@
     <LibraryObject Name="MTBasics" Source="Libraries._AS.MTBasics.lby" Memory="UserROM" Language="binary" Debugging="true" />
     <LibraryObject Name="LoopConR" Source="Libraries._AS.LoopConR.lby" Memory="UserROM" Language="Binary" Debugging="true" />
     <LibraryObject Name="MTLookUp" Source="Libraries._AS.MTLookUp.lby" Memory="UserROM" Language="binary" Debugging="true" />
+    <LibraryObject Name="Persist" Source="Libraries.Loupe.Persist.lby" Memory="UserROM" Language="ANSIC" Debugging="true" />
   </Libraries>
 </SwConfiguration>


### PR DESCRIPTION
## What
Adds a `<LibraryObject Name="Persist" .../>` entry to both `Cpu.sw` files (Intel + ARM).

## Why
`@loupeteam/persist@1.0.0` was published missing all `.br` files. Without the lib being developed registered as a `<LibraryObject>` in the configuration's `Cpu.sw`, AS6 compiles the lib's `.a` but doesn't include it in the configuration's runtime image, so no `.br` is generated. The export-as-library action then ships only the `.a`, producing a broken tarball.

Same class of bug as VarTools#15 / DirIOWrap (in flight). Fix is a 2-line addition per Cpu.sw.

## Verification
After this change, `Temp/Objects/Intel/.../Persist.br` and `Temp/Objects/ARM/.../Persist.br` are both produced. Intel + ARM builds clean.

## Follow-up
Once merged:
1. Delete the broken `@loupeteam/persist@1.0.0` GitHub Package version
2. Trigger `build-export-publish.yml` workflow with version `v1.0.0` to republish

`UPGRADE_TO_AS6.md` step 7c now requires this entry for all migrations going forward.